### PR TITLE
Add Tinkers OreDict Cache

### DIFF
--- a/Performance/Performance112.md
+++ b/Performance/Performance112.md
@@ -12,6 +12,7 @@ Join our [discord](https://discord.gg/8nzHYhVUQS) or use the issues.
 
 | Name | Known Incompatibilities | Description | Author | Performance Improvement | [Label](/README.md/#labels) |
 | --- | :---: | :---: | :---: | :---: | :---: |
+| [Tinkers OreDict Cache](https://www.curseforge.com/minecraft/mc-mods/tinkers-oredict-cache) | Unknown | This mod caches tinkers construct melting recipes to speed up game loading time | youyihj | Both | none |
 | [AE2 Unofficial Extended Life](https://www.curseforge.com/minecraft/mc-mods/ae2-extended-life) | Applied Energistics 2 | This is a Fork of [Applied Energistcs 2](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2) since 1.12.2 in no longer supported, This version of AE2 comes with many bugfixes and performance improvments | PrototypeTrousers | Both | none |
 | [AI Improvements](https://www.curseforge.com/minecraft/mc-mods/ai-improvements) | None | Simplified AI modification mod focused on performance and low-level modifications to AIs in the game | QueenOfMissiles | Server | none |
 | [Better Biome Blend](https://www.curseforge.com/minecraft/mc-mods/better-biome-blend) | None | Better Biome Blend is a mod  which accelerates the biome color blending algorithm. | FionaTheMortal | Client | none |


### PR DESCRIPTION
> Tinkers' Construct scans all recipes to register ore dictory based smelting recipes, such as golden sword => 288mB molten gold. However, there are thousands of recipes in massive modpacks. The game would scan them every game loading and take much time. This mod caches all smelting recipes and stops Tinkers' Construct scanning all recipes over and over again. Performance optimization would appear on the second load.